### PR TITLE
Scroll new messages into view

### DIFF
--- a/renderer/src/components/global/displays/MessagesDisplay.tsx
+++ b/renderer/src/components/global/displays/MessagesDisplay.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef, useEffect } from "react";
 
 //components
 import ErrorMessage from "./messages/ErrorMessage";
@@ -8,6 +8,12 @@ import CodeDisplay from "./CodeDisplay";
 
 //types
 import Loading from "../Loading";
+
+const ScrollIntoView = () => {
+  const elementRef = useRef<null | HTMLDivElement>();
+  useEffect(() => elementRef.current.scrollIntoView());
+  return <div ref={elementRef} />;
+};
 
 interface MessagesDisplayProps {
   messages: any;


### PR DESCRIPTION
### **Important fix**

Notice how in the screen cap below, after typing my answers to the questions, the final results returned are not scrolled into view, which can leave the user waiting, unaware the result has been returned, and has to manually scroll down:

https://github.com/february-labs/devgpt-releases/assets/35680780/419c2e4a-8a3d-4d92-a1ef-e8241c3382f8

---
In this PR, all new messages are scrolled into the user's view:
---

https://github.com/february-labs/devgpt-releases/assets/35680780/484ce598-a171-4125-b426-eb8a63c5cb4f