### PR TITLE
Fix broken keyboard shortcut to open target repo

### DIFF
--- a/renderer/src/components/global/sidebar/elements/MenuTabs.tsx
+++ b/renderer/src/components/global/sidebar/elements/MenuTabs.tsx
@@ -121,7 +121,7 @@ const MenuTabs = () => {
     {
       name: "New Task",
       icon: FiPlus,
-      command: checkOS("⌘ + T", "Ctrl + T"),
+      command: checkOS("⌘ + N", "Ctrl + N"),
       onClick: () => {
         newTaskHandler();
       },
@@ -211,10 +211,15 @@ const MenuTabs = () => {
     shell.openExternal("https://february-labs.gitbook.io/february-labs/");
   });
 
-  // Listens for Cmd+T and Ctrl+T to create a new task
-  useGlobalKeyboardShortcut("t", () => {
+  // Listens for Cmd+N and Ctrl+N to create a new task
+  useGlobalKeyboardShortcut("n", () => {
     setNewTaskCreated(true);
     router.push(`/platform/transactions/new`);
+  });
+
+  // Listens for Cmd+T and Ctrl+T to select target repo
+  useGlobalKeyboardShortcut("t", () => {
+    openRepoSettings();
   });
 
   // Listens for Cmd+B and Ctrl+B to report bugs


### PR DESCRIPTION
The keyboard shortcut shown in the sidebar for "Create new task" and "Select target repo" were both assigned to the same key (control + T)

Pressing `control + T` would only create a new task, attemping to select target repo from keyboard doesn't work.

<img width="318" alt="Screen Shot 2023-09-12 at 21 23 37" src="https://github.com/february-labs/devgpt-releases/assets/35680780/584082e0-a8a7-4bf5-aeb4-8eac2778b927">


Turns out there was no listener for target repo keyboard event

This PR includes two fixes:

1: 
Keyboard events are no longer overlapping
New task is now `control + N`
Selected target repo is now `control + T`

2:
Added the listener to `control + T` keyboard event to switch selected target repo when pressed

<img width="317" alt="Screen Shot 2023-09-12 at 21 20 59" src="https://github.com/february-labs/devgpt-releases/assets/35680780/681adc80-0683-4965-b4e0-ce4d6e57477f">
