### PR TITLE
Add task deletion UI fixes & add confirmation alert before deleting a task

### DIFF
--- a/renderer/src/components/global/AlertConfirmation.tsx
+++ b/renderer/src/components/global/AlertConfirmation.tsx
@@ -1,0 +1,43 @@
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  Button,
+} from "@chakra-ui/react";
+import { useRef } from "react";
+
+const AlertConfirmation = ({ isOpen, onClose, onConfirm, title, bodyText }) => {
+  const cancelRef = useRef();
+
+  return (
+    <AlertDialog
+      isOpen={isOpen}
+      leastDestructiveRef={cancelRef}
+      onClose={onClose}
+    >
+      <AlertDialogOverlay>
+        <AlertDialogContent>
+          <AlertDialogHeader fontSize="lg" fontWeight="bold">
+            {title}
+          </AlertDialogHeader>
+
+          <AlertDialogBody>{bodyText}</AlertDialogBody>
+
+          <AlertDialogFooter>
+            <Button ref={cancelRef} onClick={onClose}>
+              Cancel
+            </Button>
+            <Button colorScheme="red" onClick={onConfirm} ml={3}>
+              Delete
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialogOverlay>
+    </AlertDialog>
+  );
+};
+
+export default AlertConfirmation;

--- a/renderer/src/components/global/sidebar/elements/TaskTabs.tsx
+++ b/renderer/src/components/global/sidebar/elements/TaskTabs.tsx
@@ -1,5 +1,15 @@
 import React, { useState, useEffect } from "react";
-import { Box, useToast } from "@chakra-ui/react";
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  Box,
+  Button,
+  useToast,
+} from "@chakra-ui/react";
 import { AiOutlineDelete } from "react-icons/ai";
 import { FiMessageSquare } from "react-icons/fi";
 import router from "next/router";
@@ -8,6 +18,7 @@ import deleteTask from "@/src/utils/deleteTask";
 import NavItem from "../../navigation/NavItem";
 import { useAuthContext } from "@/src/context";
 import getTasks from "@/src/utils/getTasks";
+import AlertConfirmation from "../../AlertConfirmation";
 
 interface TaskTabsProps {
   tasks: any;
@@ -18,6 +29,7 @@ interface TaskTabsProps {
 
 const TaskTabs = ({ tasks, setTasks, refresh, setRefresh }: TaskTabsProps) => {
   const [tasksLoaded, setTasksLoaded] = useState(false);
+  const [deletingTask, setDeletingTask] = useState(null);
 
   const { user } = useAuthContext();
   const toast = useToast();
@@ -35,6 +47,16 @@ const TaskTabs = ({ tasks, setTasks, refresh, setRefresh }: TaskTabsProps) => {
 
   return (
     <Box>
+      <AlertConfirmation
+        isOpen={deletingTask !== null}
+        onClose={() => setDeletingTask(null)}
+        onConfirm={() => {
+          deleteTask(deletingTask.transaction_id, toast, refresh, setRefresh);
+          setDeletingTask(null);
+        }}
+        title={"Delete task"}
+        bodyText={"Are you sure? This permanently deletes this task."}
+      />
       {tasks.length === 0 ? (
         <NavItem iconColor="white">
           {tasksLoaded ? "No tasks found yet" : "Loading tasks..."}
@@ -52,13 +74,19 @@ const TaskTabs = ({ tasks, setTasks, refresh, setRefresh }: TaskTabsProps) => {
                   : "gray.900"
               }
               borderRadius={0}
+              position={"relative"}
               secondIcon={
                 <Box
-                  mr={4}
+                  position="absolute"
+                  right={0}
+                  top={0}
+                  height="100%"
+                  display="flex"
+                  alignItems={"center"}
+                  pr={4}
                   onClick={(e) => {
                     e.stopPropagation();
-
-                    deleteTask(task.transaction_id, toast, refresh, setRefresh);
+                    setDeletingTask(task);
                   }}
                 >
                   <AiOutlineDelete color={"#E53E3E"} />


### PR DESCRIPTION
Notice in the video below how hovering over a task breaks the UI.
A trash icon pops up on the left side and moves the rest of the content over.


https://github.com/february-labs/devgpt-releases/assets/35680780/4142c4b2-215a-4336-8c5f-549c9146c87b

Also notice how clicking delete immediately deletes the task, without prompting the user if they really wish to take this permanent action.

---

Instead, the empty space on the right side of the task can be utilized to add a floating trash icon, that way the content stays consistently in the same position.

In addition, when the delete icon is clicked, an alert dialogue pops up. Only after confirming the dialogue does the task get deleted:

https://github.com/february-labs/devgpt-releases/assets/35680780/274f0bca-38ff-4787-a89a-ab030d7df235

