### PR TITLE
Update Linux installation file format in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Once you have the DevGPT release package, follow these straightforward installat
 
 `Windows: .exe`
 
-`Linux: .snap OR AppImage`
+`Linux: .AppImage`
 
 If you have any questions about installation, get in touch with our team via [Discord](https://discord.com/invite/6GFtwzuvtw)!
 


### PR DESCRIPTION
The Linux installation was previously listed in the README, documenting either .snap or AppImage formats. This has been updated to .AppImage format exclusively. This change is made to clarify the Linux installation process and remove any confusion for the users.

In the Release Page, there is no longer a .snap file. If this is intentional, we need to update the README.